### PR TITLE
Prevent to override the first request in redis if the same idempotency key is provided for two different requests in parallel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All changes to `grape-idempotency` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.1] - 2023-01-03
+## [0.1.1] - 2023-01-06
 
 ### Fix
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All changes to `grape-idempotency` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] - 2023-01-03
+
+### Fix
+
+- Return `409 - Conflict` response if idempotency key is provided for same query and body parameters BUT different endpoints.
+- Use `nx: true` when storing the original request in the Redis storage for only setting the key if it does not already exist.
+
+### Changed
+
+- Include `idempotency-key` in the response headers
+  - In the case of a concurrency error when storing the request into the redis storage (because now `nx: true`), a new idempotency key will be generated, so the consumer can check the new one seeing the headers.
+
 ## [0.1.0] - 2023-01-03
 
 - Initial version

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Keys are automatically removed from the system if they are at least 24 hours old
 
 Results are only saved if an API endpoint begins its execution. If incoming parameters fail validation or if the request conflicts with another one executing concurrently, no idempotent result is stored because no API endpoint has initiated execution. In such cases, retrying these requests is safe.
 
-Additionally, this gem automatically appends the `Original-Request` header and the `Idempotent-Key` header to your API's response, enabling you to trace back to the initial request that generated that specific response.
+Additionally, this gem automatically appends the `Original-Request` header and the `Idempotency-Key` header to your API's response, enabling you to trace back to the initial request that generated that specific response.
 
 ## Configuration 🪚
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
-# grape-idempotency 🍇🔁
+# Grape::Idempotency 🍇🔁
 
 [![Gem Version](https://badge.fury.io/rb/grape-idempotency.svg)](https://badge.fury.io/rb/grape-idempotency)
 [![Build Status](https://github.com/jcagarcia/grape-idempotency/actions/workflows/ruby.yml/badge.svg?branch=main)](https://github.com/jcagarcia/grape-idempotency/actions)
 
 Gem for supporting idempotency in your [Grape](https://github.com/ruby-grape/grape) APIs.
-
 
 Topics covered in this README:
 
@@ -76,7 +75,7 @@ Keys are automatically removed from the system if they are at least 24 hours old
 
 Results are only saved if an API endpoint begins its execution. If incoming parameters fail validation or if the request conflicts with another one executing concurrently, no idempotent result is stored because no API endpoint has initiated execution. In such cases, retrying these requests is safe.
 
-Additionally, this gem automatically appends the `Original-Request` header to your API's response, enabling you to trace back to the initial request that generated that specific response.
+Additionally, this gem automatically appends the `Original-Request` header and the `Idempotent-Key` header to your API's response, enabling you to trace back to the initial request that generated that specific response.
 
 ## Configuration 🪚
 

--- a/lib/grape/idempotency/version.rb
+++ b/lib/grape/idempotency/version.rb
@@ -2,6 +2,6 @@
 
 module Grape
   module Idempotency
-    VERSION = '0.1.0'
+    VERSION = '0.1.1'
   end
 end


### PR DESCRIPTION
This PR includes:

1. #3 
2. Return conflict if idempotency key is provided for same query and body parameters BUT different endpoints
3. Including `idempotency-key` in the response headers