### PR TITLE
Add processing response

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,17 @@ Grape::Idempotency.configure do |c|
 end
 ```
 
+### processing_response
+
+When a request with a `Idempotency-Key: <key>` header is performed while a previous one still on going with the same idempotency value, this gem returns a `102 - Processing` status. Thre response body returned by the gem looks like:
+
+```json
+{
+
+  "message": "A request with the same idempotency key is being processed"
+}
+
+
 In the configuration above, the error is following the [RFC-7807](https://datatracker.ietf.org/doc/html/rfc7807) format.
 
 ## Changelog

--- a/README.md
+++ b/README.md
@@ -132,8 +132,8 @@ When providing a `Idempotency-Key: <key>` header, this gem compares incoming par
 ```json
 {
 
-  title: "Idempotency-Key is already used",
-  detail: "This operation is idempotent and it requires correct usage of Idempotency Key. Idempotency Key MUST not be reused across different payloads of this operation."
+  "title": "Idempotency-Key is already used",
+  "detail": "This operation is idempotent and it requires correct usage of Idempotency Key. Idempotency Key MUST not be reused across different payloads of this operation."
 }
 ```
 
@@ -158,8 +158,8 @@ When a request with a `Idempotency-Key: <key>` header is performed while a previ
 ```json
 {
 
-  title: "A request is outstanding for this Idempotency-Key",
-  detail: "A request with the same idempotent key for the same operation is being processed or is outstanding."
+  "title": "A request is outstanding for this Idempotency-Key",
+  "detail": "A request with the same idempotent key for the same operation is being processed or is outstanding."
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ To execute an idempotent request, simply request your user to include an extra `
 This gem operates by storing the initial request's status code and response body, regardless of whether the request succeeded or failed, using a specific idempotency key. Subsequent requests with the same key will consistently yield the same result, even if there were 500 errors.
 
 Keys are automatically removed from the system if they are at least 24 hours old, and a new request is generated when a key is reused after the original has been removed. The idempotency layer compares incoming parameters to those of the original request and returns a `409 - Conflict` status code if they don't match, preventing accidental misuse.
+If a request is received while another one with the same idempotency key is received is still being processed the idempotency layer returns a `409 - Conflict` status
 
 Results are only saved if an API endpoint begins its execution. If incoming parameters fail validation or if the request conflicts with another one executing concurrently, no idempotent result is stored because no API endpoint has initiated execution. In such cases, retrying these requests is safe.
 
@@ -151,12 +152,12 @@ end
 
 ### processing_response
 
-When a request with a `Idempotency-Key: <key>` header is performed while a previous one still on going with the same idempotency value, this gem returns a `102 - Processing` status. Thre response body returned by the gem looks like:
+When a request with a `Idempotency-Key: <key>` header is performed while a previous one still on going with the same idempotency value, this gem returns a `409 - Conflict` status. Thre response body returned by the gem looks like:
 
 ```json
 {
 
-  "message": "A request with the same idempotency key is being processed"
+  "message": "A request with the same idempotent key for the same operation is being processed or is outstanding."
 }
 
 

--- a/lib/grape/idempotency.rb
+++ b/lib/grape/idempotency.rb
@@ -222,11 +222,13 @@ module Grape
         @expires_in = 216_000
         @idempotency_key_header = "idempotency-key"
         @request_id_header = "x-request-id"
-        @conflict_error_response = { 
-          "error" => "You are using the same idempotent key for two different requests"
+        @conflict_error_response = {
+          "title" => "Idempotency-Key is already used",
+          "detail" => "This operation is idempotent and it requires correct usage of Idempotency Key. Idempotency Key MUST not be reused across different payloads of this operation."
         }
         @processing_response = {
-          "message" => "A request with the same idempotent key for the same operation is being processed or is outstanding."
+          "title" => "A request is outstanding for this Idempotency-Key",
+          "detail" => "A request with the same idempotent key for the same operation is being processed or is outstanding."
         }
       end
     end

--- a/spec/idempotent_spec.rb
+++ b/spec/idempotent_spec.rb
@@ -64,7 +64,7 @@ describe Grape::Idempotency do
                   end
                 end
 
-                expect(storage).to receive(:set).once.and_call_original
+                expect(storage).to receive(:set).twice.and_call_original
     
                 header "idempotency-key", idempotency_key
                 post 'payments?locale=es', { amount: 100_00 }.to_json
@@ -198,7 +198,7 @@ describe Grape::Idempotency do
           end
   
           context 'and there is NOT a response already stored in the storage' do
-            it 'stores the response in the storage' do
+            it 'stores the the request as processing initially without overwritting and later stores the response' do
               expected_response_body = { error: "Internal Server Error" }
               app.post('/payments') do
                 idempotent do
@@ -206,17 +206,26 @@ describe Grape::Idempotency do
                   expected_response_body.to_json
                 end
               end
-  
+
               expect(storage).to receive(:set) do |key, body, opts|
                 expect(key).to eq("grape:idempotency:#{idempotency_key}")
                 json_body = JSON.parse(body, symbolize_names: true)
-                expect(json_body[:response]).to eq(expected_response_body.to_json)
+                expect(json_body[:path]).to eq("/payments")
+                expect(json_body[:params]).to eq({:"locale"=>"undefined", :"{\"amount\":10000}"=>nil})
+                expect(opts).to eq({ex: 216_000, nx: true})
+              end
+
+              expect(storage).to receive(:set) do |key, body, opts|
+                expect(key).to eq("grape:idempotency:#{idempotency_key}")
+                json_body = JSON.parse(body, symbolize_names: true)
                 expect(json_body[:path]).to eq("/payments")
                 expect(json_body[:params]).to eq({:"locale"=>"undefined", :"{\"amount\":10000}"=>nil})
                 expect(json_body[:status]).to eq(500)
-                expect(opts).to eq({ex: 216_000, nx: true})
+                expect(json_body[:response]).to eq(expected_response_body.to_json)
+                expect(opts).to eq({ex: 216_000, nx: false})
               end
-      
+
+
               header "idempotency-key", idempotency_key
               post 'payments?locale=undefined', { amount: 100_00 }.to_json
             end
@@ -291,25 +300,6 @@ describe Grape::Idempotency do
               header "idempotency-key", idempotency_key
               post 'payments?locale=undefined', { amount: 100_00 }.to_json
               expect(last_response.headers).to include("idempotency-key" => idempotency_key)
-            end
-
-            context 'because parallel requests and not stored yet when performing the check' do
-              it 'stores the request using a new random idempotency key and returns it in the header response' do
-                expected_idempotency_key = 'a-idempotency-key-value'
-                app.post('/payments') do
-                  idempotent do
-                    status 201
-                    { }.to_json
-                  end
-                end
-
-                allow(SecureRandom).to receive(:uuid).and_return(expected_idempotency_key)
-                allow(storage).to receive(:set).and_return(false, true)
-        
-                header "idempotency-key", idempotency_key
-                post 'payments?locale=undefined', { amount: 100_00 }.to_json
-                expect(last_response.headers).to include("idempotency-key" => expected_idempotency_key)
-              end
             end
           end
         end
@@ -386,6 +376,10 @@ describe Grape::Idempotency do
 
         expect(storage).to receive(:set) do |key, body, opts|
           expect(opts).to eq({ex: 1800, nx: true})
+        end
+
+        expect(storage).to receive(:set) do |key, body, opts|
+          expect(opts).to eq({ex: 1800, nx: false})
         end
 
         header "idempotency-key", idempotency_key
@@ -501,6 +495,47 @@ describe Grape::Idempotency do
         post 'payments?locale=en', { amount: 800_00 }.to_json
         expect(last_response.status).to eq(409)
         expect(last_response.body).to eq("{:error=>\"An error wadus with conflict\", :status=>409, :message=>\"You are using the same idempotency key for two different requests\"}")
+      end
+    end
+
+    describe 'processing_response' do
+      let(:expected_processing_request) do
+        {
+          message: "A request with the same idempotency key is being processed",
+          status: 102
+        }
+      end
+
+      before do
+        Grape::Idempotency.configure do |c|
+          c.storage = storage
+          c.processing_response = expected_processing_request
+        end
+      end
+
+      it 'returns an 102 processing http response using the configured processing response' do
+        app.post('/payments') do
+          idempotent do
+            status 200
+
+            { some: 'value' }.to_json
+          end
+        end
+
+        processing_body = {
+          path: '/payments',
+          params: { 'locale' => 'es' },
+          original_request: 'request-id',
+          processing: true
+        }
+
+        allow(storage).to receive(:get).with("grape:idempotency:#{idempotency_key}").and_return(processing_body.to_json)
+
+        header "idempotency-key", idempotency_key
+        post 'payments?locale=en', { amount: 800_00 }.to_json
+
+        expect(last_response.status).to eq(102)
+        expect(last_response.body).to eq(expected_processing_request.to_json)
       end
     end
   end

--- a/spec/idempotent_spec.rb
+++ b/spec/idempotent_spec.rb
@@ -162,7 +162,7 @@ describe Grape::Idempotency do
                 header "idempotency-key", idempotency_key
                 post 'payments?locale=en', { amount: 800_00 }.to_json
                 expect(last_response.status).to eq(409)
-                expect(last_response.body).to eq("{\"error\"=>\"You are using the same idempotent key for two different requests\"}")
+                expect(last_response.body).to eq("{\"title\"=>\"Idempotency-Key is already used\", \"detail\"=>\"This operation is idempotent and it requires correct usage of Idempotency Key. Idempotency Key MUST not be reused across different payloads of this operation.\"}")
               end
             end
 
@@ -192,7 +192,7 @@ describe Grape::Idempotency do
                 header "idempotency-key", idempotency_key
                 post 'refunds?locale=es', { amount: 100_00 }.to_json
                 expect(last_response.status).to eq(409)
-                expect(last_response.body).to eq("{\"error\"=>\"You are using the same idempotent key for two different requests\"}")
+                expect(last_response.body).to eq("{\"title\"=>\"Idempotency-Key is already used\", \"detail\"=>\"This operation is idempotent and it requires correct usage of Idempotency Key. Idempotency Key MUST not be reused across different payloads of this operation.\"}")
               end
             end
           end
@@ -245,7 +245,7 @@ describe Grape::Idempotency do
                 post 'payments?locale=es', { amount: 100_00 }.to_json
 
                 expect(last_response.status).to eq(409)
-                expect(last_response.body).to eq("{\"message\"=>\"A request with the same idempotent key for the same operation is being processed or is outstanding.\"}")
+                expect(last_response.body).to eq("{\"title\"=>\"A request is outstanding for this Idempotency-Key\", \"detail\"=>\"A request with the same idempotent key for the same operation is being processed or is outstanding.\"}")
               end
             end
 


### PR DESCRIPTION
- Store the request as processing before executing the code and return a processing response (102 http status code)
- Store the response and remove the processing status to the document
- Removed the  random idempotency key as is not necessary now

Fix #10  

