### PR TITLE
feature(#14): Allow to make idempotency key header mandatory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,31 +4,48 @@ All changes to `grape-idempotency` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0] - (Next)
+
+### Fix
+
+* Your contribution here.
+
+### Changed
+
+* [#11](https://github.com/jcagarcia/grape-idempotency/pull/11): Changing error response formats - [@Flip120](https://github.com/Flip120).
+* Your contribution here.
+
+### Feature
+
+* [#15](https://github.com/jcagarcia/grape-idempotency/pull/15): Allow to mark the idempotent header as required - [@jcagarcia](https://github.com/jcagarcia).
+* [#11](https://github.com/jcagarcia/grape-idempotency/pull/11): Return 409 conflict when a request is still being processed - [@Flip120](https://github.com/Flip120).
+* Your contribution here.
+
 ## [0.1.3] - 2023-01-07
 
 ### Fix
 
-- Second calls were returning `null` when the first response was generated inside a `rescue_from`.
-- Conflict response had invalid format.
+* [#9](https://github.com/jcagarcia/grape-idempotency/pull/9): Second calls were returning `null` when the first response was generated inside a `rescue_from`. - [@jcagarcia](https://github.com/jcagarcia).
+- [#9](https://github.com/jcagarcia/grape-idempotency/pull/9): Conflict response had invalid format. - [@jcagarcia](https://github.com/jcagarcia).
 
 ## [0.1.2] - 2023-01-06
 
 ### Fix
 
-- Return correct original response when the endpoint returns a hash in the body
+* [#5](https://github.com/jcagarcia/grape-idempotency/pull/5): Return correct original response when the endpoint returns a hash in the body - [@jcagarcia](https://github.com/jcagarcia).
 
 ## [0.1.1] - 2023-01-06
 
 ### Fix
 
-- Return `409 - Conflict` response if idempotency key is provided for same query and body parameters BUT different endpoints.
-- Use `nx: true` when storing the original request in the Redis storage for only setting the key if it does not already exist.
+* [#4](https://github.com/jcagarcia/grape-idempotency/pull/4): Return `409 - Conflict` response if idempotency key is provided for same query and body parameters BUT different endpoints. - [@jcagarcia](https://github.com/jcagarcia).
+* [#4](https://github.com/jcagarcia/grape-idempotency/pull/4): Use `nx: true` when storing the original request in the Redis storage for only setting the key if it does not already exist. - [@jcagarcia](https://github.com/jcagarcia).
 
 ### Changed
 
-- Include `idempotency-key` in the response headers
-  - In the case of a concurrency error when storing the request into the redis storage (because now `nx: true`), a new idempotency key will be generated, so the consumer can check the new one seeing the headers.
+* [#4](https://github.com/jcagarcia/grape-idempotency/pull/4): Include `idempotency-key` in the response headers - [@jcagarcia](https://github.com/jcagarcia).
+  * In the case of a concurrency error when storing the request into the redis storage (because now `nx: true`), a new idempotency key will be generated, so the consumer can check the new one seeing the headers.
 
 ## [0.1.0] - 2023-01-03
 
-- Initial version
+* [#1](https://github.com/jcagarcia/grape-idempotency/pull/1): Initial version - [@jcagarcia](https://github.com/jcagarcia).

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Topics covered in this README:
 - [Installation](#installation-)
 - [Basic Usage](#basic-usage-)
 - [How it works](#how-it-works-)
-- [Making idempotency key header mandatory](#making-idempotency-key-header-mandatory)
+- [Making idempotency key header mandatory](#making-idempotency-key-header-mandatory-)
 - [Configuration](#configuration-)
 - [Changelog](#changelog)
 - [Contributing](#contributing)

--- a/lib/grape/idempotency/helpers.rb
+++ b/lib/grape/idempotency/helpers.rb
@@ -1,8 +1,8 @@
 module Grape
   module Idempotency
     module Helpers
-      def idempotent(&block)
-        Grape::Idempotency.idempotent(self) do
+      def idempotent(required: false, &block)
+        Grape::Idempotency.idempotent(self, required: required) do
           block.call
         end
       end

--- a/spec/idempotent_spec.rb
+++ b/spec/idempotent_spec.rb
@@ -162,7 +162,7 @@ describe Grape::Idempotency do
                 header "idempotency-key", idempotency_key
                 post 'payments?locale=en', { amount: 800_00 }.to_json
                 expect(last_response.status).to eq(409)
-                expect(last_response.body).to eq("{\"title\"=>\"Idempotency-Key is already used\", \"detail\"=>\"This operation is idempotent and it requires correct usage of Idempotency Key. Idempotency Key MUST not be reused across different payloads of this operation.\"}")
+                expect(last_response.body).to eq("{\"title\":\"Idempotency-Key is already used\",\"detail\":\"This operation is idempotent and it requires correct usage of Idempotency Key. Idempotency Key MUST not be reused across different payloads of this operation.\"}")
               end
             end
 
@@ -192,7 +192,7 @@ describe Grape::Idempotency do
                 header "idempotency-key", idempotency_key
                 post 'refunds?locale=es', { amount: 100_00 }.to_json
                 expect(last_response.status).to eq(409)
-                expect(last_response.body).to eq("{\"title\"=>\"Idempotency-Key is already used\", \"detail\"=>\"This operation is idempotent and it requires correct usage of Idempotency Key. Idempotency Key MUST not be reused across different payloads of this operation.\"}")
+                expect(last_response.body).to eq("{\"title\":\"Idempotency-Key is already used\",\"detail\":\"This operation is idempotent and it requires correct usage of Idempotency Key. Idempotency Key MUST not be reused across different payloads of this operation.\"}")
               end
             end
           end
@@ -339,6 +339,24 @@ describe Grape::Idempotency do
 
             post 'payments', { amount: 100_00 }.to_json
             expect(last_response.body).to eq({ amount_to: 2 }.to_json)
+          end
+
+          context 'BUT the idempotency key header was mandatory' do
+            it 'returns 400 bad request response' do
+              app.post('/payments') do
+                idempotent(required: true) do
+                  status 201
+                  { amount_to: SecureRandom.random_number }.to_json
+                end
+              end
+
+              post 'payments', { amount: 100_00 }.to_json
+              expect(last_response.body).to eq({
+                title: "Idempotency-Key is missing",
+                detail: "This operation is idempotent and it requires correct usage of Idempotency Key."
+              }.to_json)
+              expect(last_response.status).to eq(400)
+            end
           end
         end
       end
@@ -513,7 +531,7 @@ describe Grape::Idempotency do
         header "idempotency-key", idempotency_key
         post 'payments?locale=en', { amount: 800_00 }.to_json
         expect(last_response.status).to eq(409)
-        expect(last_response.body).to eq("{:error=>\"An error wadus with conflict\", :status=>409, :message=>\"You are using the same idempotency key for two different requests\"}")
+        expect(last_response.body).to eq("{\"error\":\"An error wadus with conflict\",\"status\":409,\"message\":\"You are using the same idempotency key for two different requests\"}")
       end
     end
 


### PR DESCRIPTION
Now, when wrapping the code inside `idempotent` helper, you can provide `required` parameter to enforce consumers to pass `Idempotency-Key` header when performing the idempotent operation.