### PR TITLE
Return Unprocessable Entity error for conflict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* [#16](https://github.com/jcagarcia/grape-idempotency/pull/16): Changing error response code to 422 for conflict - [@Flip120](https://github.com/Flip120).
 * [#11](https://github.com/jcagarcia/grape-idempotency/pull/11): Changing error response formats - [@Flip120](https://github.com/Flip120).
+
 * Your contribution here.
 
 ### Feature

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ To execute an idempotent request, simply request your user to include an extra `
 
 This gem operates by storing the initial request's status code and response body, regardless of whether the request succeeded or failed, using a specific idempotency key. Subsequent requests with the same key will consistently yield the same result, even if there were 500 errors.
 
-Keys are automatically removed from the system if they are at least 24 hours old, and a new request is generated when a key is reused after the original has been removed. The idempotency layer compares incoming parameters to those of the original request and returns a `409 - Conflict` status code if they don't match, preventing accidental misuse.
+Keys are automatically removed from the system if they are at least 24 hours old, and a new request is generated when a key is reused after the original has been removed. The idempotency layer compares incoming parameters to those of the original request and returns a `422 - Unprocessable Entity` status code if they don't match, preventing accidental misuse.
 If a request is received while another one with the same idempotency key is still being processed the idempotency layer returns a `409 - Conflict` status
 
 Results are only saved if an API endpoint begins its execution. If incoming parameters fail validation or if the request conflicts with another one executing concurrently, no idempotent result is stored because no API endpoint has initiated execution. In such cases, retrying these requests is safe.

--- a/lib/grape/idempotency.rb
+++ b/lib/grape/idempotency.rb
@@ -31,7 +31,7 @@ module Grape
 
         cached_request = get_from_cache(idempotency_key)
         if cached_request && (cached_request["params"] != grape.request.params || cached_request["path"] != grape.request.path)
-          grape.error!(configuration.conflict_error_response, 409)
+          grape.error!(configuration.conflict_error_response, 422)
         elsif cached_request && cached_request["processing"] == true
           grape.error!(configuration.processing_response, 409)
         elsif cached_request
@@ -44,8 +44,7 @@ module Grape
         original_request_id = get_request_id(grape.request.headers)
         success = store_processing_request(idempotency_key, grape.request.path, grape.request.params, original_request_id)
         if !success
-          grape.status 409
-          return configuration.processing_response
+          grape.error!(configuration.processing_response, 409)
         end
 
         response = catch(:error) do

--- a/spec/idempotent_spec.rb
+++ b/spec/idempotent_spec.rb
@@ -161,7 +161,7 @@ describe Grape::Idempotency do
 
                 header "idempotency-key", idempotency_key
                 post 'payments?locale=en', { amount: 800_00 }.to_json
-                expect(last_response.status).to eq(409)
+                expect(last_response.status).to eq(422)
                 expect(last_response.body).to eq("{\"title\":\"Idempotency-Key is already used\",\"detail\":\"This operation is idempotent and it requires correct usage of Idempotency Key. Idempotency Key MUST not be reused across different payloads of this operation.\"}")
               end
             end
@@ -191,7 +191,7 @@ describe Grape::Idempotency do
 
                 header "idempotency-key", idempotency_key
                 post 'refunds?locale=es', { amount: 100_00 }.to_json
-                expect(last_response.status).to eq(409)
+                expect(last_response.status).to eq(422)
                 expect(last_response.body).to eq("{\"title\":\"Idempotency-Key is already used\",\"detail\":\"This operation is idempotent and it requires correct usage of Idempotency Key. Idempotency Key MUST not be reused across different payloads of this operation.\"}")
               end
             end
@@ -245,7 +245,7 @@ describe Grape::Idempotency do
                 post 'payments?locale=es', { amount: 100_00 }.to_json
 
                 expect(last_response.status).to eq(409)
-                expect(last_response.body).to eq("{\"title\"=>\"A request is outstanding for this Idempotency-Key\", \"detail\"=>\"A request with the same idempotent key for the same operation is being processed or is outstanding.\"}")
+                expect(last_response.body).to eq("{\"title\":\"A request is outstanding for this Idempotency-Key\",\"detail\":\"A request with the same idempotent key for the same operation is being processed or is outstanding.\"}")
               end
             end
 
@@ -530,7 +530,7 @@ describe Grape::Idempotency do
 
         header "idempotency-key", idempotency_key
         post 'payments?locale=en', { amount: 800_00 }.to_json
-        expect(last_response.status).to eq(409)
+        expect(last_response.status).to eq(422)
         expect(last_response.body).to eq("{\"error\":\"An error wadus with conflict\",\"status\":409,\"message\":\"You are using the same idempotency key for two different requests\"}")
       end
     end


### PR DESCRIPTION
Changes the response code to 422 instead of 409 when a request with the same idempotent key is found but with different parameters or path

Fix #13 