### PR TITLE
feat(#19): Manage  exceptions by default and allow the gem's consumer to manage them by itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All changes to `grape-idempotency` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.1] - (Next)
+## [1.1.0] - (Next)
 
 ### Fix
 
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Feature
 
+* [#20](https://github.com/jcagarcia/grape-idempotency/pull/20): Manage `Redis` exceptions by default and allow the gem's consumer to manage them by itself - [@jcagarcia](https://github.com/jcagarcia).
 * Your contribution here.
 
 ## [1.0.0] - 2023-11-23

--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ end
 
 If you want to avoid this functionality, and you want the gem handles the potential `Redis` exceptions, you have the option to configure the gem for handling these `Redis` exceptions. Please refer to the [manage_redis_exceptions](#manage_redis_exceptions) configuration property.
 
+🚨 WARNING: If a `Redis` exception appears AFTER performing the wrapped code, nothing will be re-raised. The process will continue working and the response will be returned to the consumer of your API. However, a `409 Conflict` response can be returned to your consumer if it retried the same call with the same idempotency key. This is because the gem was not able to associate the response of the original request to the original idempotency key because those connectivity issues.
+
 ## Configuration 🪚
 
 In addition to the storage aspect, you have the option to supply additional configuration details to tailor the gem to the specific requirements of your project.

--- a/grape-idempotency.gemspec
+++ b/grape-idempotency.gemspec
@@ -22,7 +22,8 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.6'
 
-  spec.add_runtime_dependency 'grape', '~> 1'
+  spec.add_runtime_dependency 'grape', '>= 1'
+  spec.add_runtime_dependency 'redis', '>= 4'
   
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rspec'

--- a/lib/grape/idempotency.rb
+++ b/lib/grape/idempotency.rb
@@ -1,4 +1,5 @@
 require 'grape'
+require 'redis'
 require 'logger'
 require 'securerandom'
 require 'grape/idempotency/version'
@@ -33,21 +34,21 @@ module Grape
         grape.error!(configuration.mandatory_header_response, 400) if required && !idempotency_key
         return block.call if !idempotency_key
 
-        cached_request = get_from_cache(idempotency_key)
-        log(:debug, "Request has been found for the provided idempotency key => #{cached_request}") if cached_request
-        if cached_request && (cached_request["params"] != grape.request.params || cached_request["path"] != grape.request.path)
-          log(:debug, "Request has conflicts. Same params? => #{cached_request["params"] != grape.request.params}. Same path? => #{cached_request["path"] != grape.request.path}")
+        stored_request = get_from_storage(idempotency_key)
+        log(:debug, "Request has been found for the provided idempotency key => #{stored_request}") if stored_request
+        if stored_request && (stored_request["params"] != grape.request.params || stored_request["path"] != grape.request.path)
+          log(:debug, "Request has conflicts. Same params? => #{stored_request["params"] != grape.request.params}. Same path? => #{stored_request["path"] != grape.request.path}")
           log(:debug, "Returning conflict error response.")
           grape.error!(configuration.conflict_error_response, 422)
-        elsif cached_request && cached_request["processing"] == true
+        elsif stored_request && stored_request["processing"] == true
           log(:debug, "Returning processing error response.")
           grape.error!(configuration.processing_response, 409)
-        elsif cached_request
+        elsif stored_request
           log(:debug, "Returning the response from the original request.")
-          grape.status cached_request["status"]
-          grape.header(ORIGINAL_REQUEST_HEADER, cached_request["original_request"])
+          grape.status stored_request["status"]
+          grape.header(ORIGINAL_REQUEST_HEADER, stored_request["original_request"])
           grape.header(configuration.idempotency_key_header, idempotency_key)
-          return cached_request["response"]
+          return stored_request["response"]
         end
 
         log(:debug, "Previous request information has NOT been found for the provided idempotency key.")
@@ -76,26 +77,32 @@ module Grape
 
         grape.header(ORIGINAL_REQUEST_HEADER, original_request_id)
         grape.body response
+      rescue Redis::BaseError => e
+        raise
       rescue => e
         log(:debug, "An unexpected error was raised when performing the block.")
-        if !cached_request && !response
+        if !stored_request && !response
           validate_config!
           log(:debug, "Storing error response.")
           original_request_id = get_request_id(grape.request.headers)
           stored_key = store_error_request(idempotency_key, grape.request.path, grape.request.params, grape.status, original_request_id, e)
-          log(:debug, "Error response stored.")
-          grape.header(ORIGINAL_REQUEST_HEADER, original_request_id)
-          grape.header(configuration.idempotency_key_header, stored_key)
+          if stored_key
+            log(:debug, "Error response stored.")
+            grape.header(ORIGINAL_REQUEST_HEADER, original_request_id)
+            grape.header(configuration.idempotency_key_header, stored_key)
+          end
         end
         log(:debug, "Re-raising the error.")
         raise
       ensure
-        if !cached_request && response
+        if !stored_request && response
           validate_config!
           log(:debug, "Storing response.")
           stored_key = store_request_response(idempotency_key, grape.request.path, grape.request.params, grape.status, original_request_id, response)
-          log(:debug, "Response stored.")
-          grape.header(configuration.idempotency_key_header, stored_key)
+          if stored_key
+            log(:debug, "Response stored.")
+            grape.header(configuration.idempotency_key_header, stored_key)
+          end
         end
       end
 
@@ -113,6 +120,10 @@ module Grape
 
         store_request_response(idempotency_key, path, params, status, original_request_id, response)
         storage.del(stored_error[:error_key])
+      rescue Redis::BaseError => e
+        log(:error, "Storage error => #{e.message} - #{e}")
+        return if configuration.manage_redis_exceptions
+        raise
       end
 
       private
@@ -122,7 +133,10 @@ module Grape
       end
 
       def valid_storage?
-        configuration.storage && configuration.storage.respond_to?(:set)
+        configuration.storage &&
+        configuration.storage.respond_to?(:get) &&
+        configuration.storage.respond_to?(:set) &&
+        configuration.storage.respond_to?(:del)
       end
 
       def get_idempotency_key(headers)
@@ -141,11 +155,15 @@ module Grape
         request_id || "req_#{SecureRandom.hex}"
       end
 
-      def get_from_cache(idempotency_key)
+      def get_from_storage(idempotency_key)
         value = storage.get(key(idempotency_key))
         return unless value
 
         JSON.parse(value)
+      rescue Redis::BaseError => e
+        log(:error, "Storage error => #{e.message} - #{e}")
+        return if configuration.manage_redis_exceptions
+        raise
       end
 
       def store_processing_request(idempotency_key, path, params, request_id)
@@ -157,6 +175,9 @@ module Grape
         }
 
         storage.set(key(idempotency_key), body.to_json, ex: configuration.expires_in, nx: true)
+      rescue Redis::BaseError => e
+        return true if configuration.manage_redis_exceptions
+        raise
       end
 
       def store_request_response(idempotency_key, path, params, status, request_id, response)
@@ -171,6 +192,10 @@ module Grape
         storage.set(key(idempotency_key), body.to_json, ex: configuration.expires_in, nx: false)
 
         idempotency_key
+      rescue Redis::BaseError => e
+        log(:error, "Storage error => #{e.message} - #{e}")
+        return if configuration.manage_redis_exceptions
+        raise
       end
 
       def store_error_request(idempotency_key, path, params, status, request_id, error)
@@ -188,6 +213,10 @@ module Grape
         storage.set(error_key(idempotency_key), body, ex: 30, nx: false)
 
         idempotency_key
+      rescue Redis::BaseError => e
+        log(:error, "Storage error => #{e.message} - #{e}")
+        return if configuration.manage_redis_exceptions
+        raise
       end
 
       def get_error_request_for(error)
@@ -207,6 +236,10 @@ module Grape
             }
           end
         end.first
+      rescue Redis::BaseError => e
+        log(:error, "Storage error => #{e.message} - #{e}")
+        return if configuration.manage_redis_exceptions
+        raise
       end
 
       def is_an_error?(response)
@@ -252,7 +285,8 @@ module Grape
 
     class Configuration
       attr_accessor :storage, :logger, :logger_level, :logger_prefix, :expires_in, :idempotency_key_header,
-        :request_id_header, :conflict_error_response, :processing_response, :mandatory_header_response
+        :request_id_header, :conflict_error_response, :processing_response, :mandatory_header_response,
+        :manage_redis_exceptions
 
       class Error < StandardError; end
 
@@ -264,6 +298,7 @@ module Grape
         @expires_in = 216_000
         @idempotency_key_header = "idempotency-key"
         @request_id_header = "x-request-id"
+        @manage_redis_exceptions = true
         @conflict_error_response = {
           "title" => "Idempotency-Key is already used",
           "detail" => "This operation is idempotent and it requires correct usage of Idempotency Key. Idempotency Key MUST not be reused across different payloads of this operation."

--- a/lib/grape/idempotency.rb
+++ b/lib/grape/idempotency.rb
@@ -122,8 +122,7 @@ module Grape
         storage.del(stored_error[:error_key])
       rescue Redis::BaseError => e
         log(:error, "Storage error => #{e.message} - #{e}")
-        return if configuration.manage_redis_exceptions
-        raise
+        nil
       end
 
       private
@@ -194,8 +193,7 @@ module Grape
         idempotency_key
       rescue Redis::BaseError => e
         log(:error, "Storage error => #{e.message} - #{e}")
-        return if configuration.manage_redis_exceptions
-        raise
+        idempotency_key
       end
 
       def store_error_request(idempotency_key, path, params, status, request_id, error)
@@ -215,8 +213,7 @@ module Grape
         idempotency_key
       rescue Redis::BaseError => e
         log(:error, "Storage error => #{e.message} - #{e}")
-        return if configuration.manage_redis_exceptions
-        raise
+        idempotency_key
       end
 
       def get_error_request_for(error)
@@ -238,8 +235,7 @@ module Grape
         end.first
       rescue Redis::BaseError => e
         log(:error, "Storage error => #{e.message} - #{e}")
-        return if configuration.manage_redis_exceptions
-        raise
+        nil
       end
 
       def is_an_error?(response)

--- a/lib/grape/idempotency.rb
+++ b/lib/grape/idempotency.rb
@@ -298,7 +298,7 @@ module Grape
         @expires_in = 216_000
         @idempotency_key_header = "idempotency-key"
         @request_id_header = "x-request-id"
-        @manage_redis_exceptions = true
+        @manage_redis_exceptions = false
         @conflict_error_response = {
           "title" => "Idempotency-Key is already used",
           "detail" => "This operation is idempotent and it requires correct usage of Idempotency Key. Idempotency Key MUST not be reused across different payloads of this operation."

--- a/lib/grape/idempotency/version.rb
+++ b/lib/grape/idempotency/version.rb
@@ -2,6 +2,6 @@
 
 module Grape
   module Idempotency
-    VERSION = '1.0.1'
+    VERSION = '1.1.0'
   end
 end


### PR DESCRIPTION
With this PR, the gem will be configurable for handling potential `Redis` exceptions. Consequently, if a `Redis` exception occurs, the idempotent behavior will be compromised, yet the application will remain stable without crashing.

Also, if some exception appears after the code is executed, instead of raising the idempotent behavior will be compromised and we will return 409 Conflict in the next call with the same idempotency key.